### PR TITLE
Feat/13: API 응답 통일 & 에러 핸들러 추가

### DIFF
--- a/src/main/java/submeet/backend/apiPayLoad/ApiResponse.java
+++ b/src/main/java/submeet/backend/apiPayLoad/ApiResponse.java
@@ -1,0 +1,32 @@
+package submeet.backend.apiPayLoad;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import submeet.backend.apiPayLoad.code.BaseCode;
+import submeet.backend.apiPayLoad.code.status.SuccessStatus;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message,data);
+    }
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/BaseCode.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/BaseCode.java
@@ -1,0 +1,6 @@
+package submeet.backend.apiPayLoad.code;
+
+public interface BaseCode {
+    public ReasonDTO getReason();
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/BaseErrorCode.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package submeet.backend.apiPayLoad.code;
+
+public interface BaseErrorCode {
+    public ErrorReasonDTO getReason();
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/ErrorReasonDTO.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/ErrorReasonDTO.java
@@ -1,0 +1,14 @@
+package submeet.backend.apiPayLoad.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/ReasonDTO.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/ReasonDTO.java
@@ -1,0 +1,14 @@
+package submeet.backend.apiPayLoad.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -1,0 +1,43 @@
+package submeet.backend.apiPayLoad.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import submeet.backend.apiPayLoad.code.BaseErrorCode;
+import submeet.backend.apiPayLoad.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 멤버 관려 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    ;
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/submeet/backend/apiPayLoad/code/status/SuccessStatus.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/status/SuccessStatus.java
@@ -1,0 +1,41 @@
+package submeet.backend.apiPayLoad.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import submeet.backend.apiPayLoad.code.BaseCode;
+import submeet.backend.apiPayLoad.code.BaseErrorCode;
+import submeet.backend.apiPayLoad.code.ReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    //일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200","success"),
+
+    //멤버 관련 응답
+    MEMBER_JOIN(HttpStatus.OK, "MEMBER2001", "member joined");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/submeet/backend/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/submeet/backend/apiPayLoad/exception/ExceptionAdvice.java
@@ -1,0 +1,120 @@
+package submeet.backend.apiPayLoad.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import submeet.backend.apiPayLoad.ApiResponse;
+import submeet.backend.apiPayLoad.code.ErrorReasonDTO;
+import submeet.backend.apiPayLoad.code.status.ErrorStatus;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+//    @Override
+//    public ResponseEntity<Object> handleMethodArgumentNotValid(
+//            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+//
+//        Map<String, String> errors = new LinkedHashMap<>();
+//
+//        e.getBindingResult().getFieldErrors().stream()
+//                .forEach(fieldError -> {
+//                    String fieldName = fieldError.getField();
+//                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+//                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+//                });
+//
+//        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+//    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/submeet/backend/apiPayLoad/exception/GeneralException.java
+++ b/src/main/java/submeet/backend/apiPayLoad/exception/GeneralException.java
@@ -1,0 +1,19 @@
+package submeet.backend.apiPayLoad.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import submeet.backend.apiPayLoad.code.BaseErrorCode;
+import submeet.backend.apiPayLoad.code.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+    private BaseErrorCode code;
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/submeet/backend/web/controller/MemberController.java
+++ b/src/main/java/submeet/backend/web/controller/MemberController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import submeet.backend.apiPayLoad.ApiResponse;
+import submeet.backend.apiPayLoad.code.status.SuccessStatus;
 import submeet.backend.converter.MemberConverter;
 import submeet.backend.entity.Member;
 import submeet.backend.service.member.MemberService;
@@ -19,9 +21,9 @@ import submeet.backend.web.dto.member.MemberResponseDTO;
 public class MemberController {
     private final MemberService memberService;
     @PostMapping("/")
-    public MemberResponseDTO.MemberJoinResultDTO join(@RequestBody MemberRequestDTO.MemberJoinDTO memberJoinDTO){
+    public ApiResponse<MemberResponseDTO.MemberJoinResultDTO> join(@RequestBody MemberRequestDTO.MemberJoinDTO memberJoinDTO){
         log.info("(controller)name : {}",memberJoinDTO.getName());
         Member member = memberService.join(memberJoinDTO);
-        return MemberConverter.toMemberJoinResultDTO(member);
+        return ApiResponse.of(SuccessStatus.MEMBER_JOIN,MemberConverter.toMemberJoinResultDTO(member));
     }
 }


### PR DESCRIPTION
- Issue : #13 
- ApiResponse 추가하여 응답 통일
- ErrorCode 및 Success Code 추가 시 ErrorStatus, SuccessStatus enum에 추가 후 사용
- Exception 관련
    - Exception 관련해서 Handler에 추가해 사용 
    - ExceptionAdvice에서 자동으로 에러 응답 통일
 
API 응답 예시
```json
{
  "isSuccess": true,
  "code": "MEMBER2001",
  "message": "회원가입 성공",
  "result": {
    "id": 1
  }
}
```