### PR TITLE
fix: db 인코딩 설정 utf-8로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
 
+  sql:
+    init:
+      encoding: utf-8
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
- 이슈번호
#19 

```yml
spring:
  datasource:
    driver-class-name: org.mariadb.jdbc.Driver
    url: ${DB_HOST}
    username: ${DB_USER}
    password: ${DB_PASSWORD}

  sql:
    init:
      encoding: utf-8
```

yml 파일 변경