### PR TITLE
Fix : 역 데이터 받을때 위치정보도 함께 받게 변경

### DIFF
--- a/src/main/java/submeet/backend/web/dto/station/StationRequestDTO.java
+++ b/src/main/java/submeet/backend/web/dto/station/StationRequestDTO.java
@@ -12,10 +12,11 @@ public class StationRequestDTO {
         private List<StationData> data;
         @Data
         public static class StationData{
-            private String line_num;
-            private String station_cd;
-            private String station_nm;
-            private String fr_code;
+            private String line;
+            private String station_code;
+            private String location;
+            private String name;
+            private String external_code;
         }
     }
 


### PR DESCRIPTION
- 기존 : 역 데이터를 먼저 받고 그 다음에 path 메서드로 위치정보를 받는 형식
```json
{
  "data": [
    {
      "line_num": "string",
      "station_cd": "string",
      "station_nm": "string",
      "fr_code": "string"
    }
  ]
}
```
- 변경 : 역 데이터와 위치정보를 함께 받는식으로 변경
```json
[
{
        "id": "779",
        "external_code": "I117",
        "line": "인천선",
        "location": "POINT(126.721514 37.517268)",
        "name": "갈산",
        "station_code": "3117"
    },
]
```