### PR TITLE
Fix : @ResponseStatus 이용해서 변경

### DIFF
--- a/src/main/java/submeet/backend/web/controller/TokenController.java
+++ b/src/main/java/submeet/backend/web/controller/TokenController.java
@@ -2,7 +2,9 @@ package submeet.backend.web.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import submeet.backend.apiPayLoad.ApiResponse;
 import submeet.backend.apiPayLoad.code.status.SuccessStatus;
@@ -16,6 +18,7 @@ import submeet.backend.web.dto.token.TokenResponseDTO;
 public class TokenController {
     private final TokenService tokenService;
 
+    @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
     @GetMapping("/token/expired")
     public ApiResponse<TokenResponseDTO.TokenRefreshDTO> refreshAuth(HttpServletRequest request) {
         String token = request.getHeader("Refresh");


### PR DESCRIPTION
저번 커밋에서 상태가 바뀌지 않아서 @ResponseStatus를 이용해서 해결
```java
@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
    @GetMapping("/token/expired")
    public ApiResponse<TokenResponseDTO.TokenRefreshDTO> refreshAuth(HttpServletRequest request) {
        String token = request.getHeader("Refresh");
        if (token != null && tokenService.verifyToken(token)) {
            String email = tokenService.getUid(token);
            Token newToken = tokenService.generateToken(email, "USER");

            return ApiResponse.of(SuccessStatus.TOKEN_REFRESHED, TokenConverter.toTokenRefreshDTO(newToken));
        }

        throw new RuntimeException("유효한 refresh 토큰이 아닙니다.");
    }
```