### PR TITLE
Feat/42 : Websocket Security 적용 및 밋 검색시 member_id, chat_room_id 반환

### DIFF
--- a/src/main/java/submeet/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_CHAT_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4002","no member chat!"),
     ALREADY_EXIST_MEMBER_CHAT(HttpStatus.BAD_REQUEST, "CHAT4003", "already exist"),
     NO_ACCESS_MEMBER_CHAT(HttpStatus.BAD_REQUEST, "CHAT4004", "채팅방에 입장중인 상태가 아닙니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CHAT4005", "no auth!"),
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/submeet/backend/config/SwaggerConfig.java
+++ b/src/main/java/submeet/backend/config/SwaggerConfig.java
@@ -20,21 +20,21 @@ public class SwaggerConfig {
                 .description("SUB MEET API 명세서")
                 .version("1.0.0");
 
-//        String jwtSchemeName = "JWT TOKEN";
-//
-//        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
-//
-//        Components components = new Components()
-//                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-//                        .name(jwtSchemeName)
-//                        .type(SecurityScheme.Type.HTTP)
-//                        .scheme("bearer")
-//                        .bearerFormat("JWT"));
+        String jwtSchemeName = "JWT TOKEN";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
 
 
         return new OpenAPI()
-                .info(info);
-//                .addSecurityItem(securityRequirement)
-//                .components(components);
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 }

--- a/src/main/java/submeet/backend/config/WebSocketConfigurer.java
+++ b/src/main/java/submeet/backend/config/WebSocketConfigurer.java
@@ -1,16 +1,19 @@
 package submeet.backend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import submeet.backend.handler.StompHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
-
+    private final StompHandler stompHandler;
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/stomp/chat")
@@ -24,4 +27,9 @@ public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
         registry.enableSimpleBroker("/sub");
     }
+
+//    @Override
+//    public void configureClientInboundChannel(ChannelRegistration registration) {
+//        registration.interceptors(stompHandler);
+//    }
 }

--- a/src/main/java/submeet/backend/converter/PostConverter.java
+++ b/src/main/java/submeet/backend/converter/PostConverter.java
@@ -9,11 +9,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class PostConverter {
-    public static PostResponseDTO.PostRegisterResultDTO toRegisterResultDTO(Post post, ChatRoom chatRoom){
+    public static PostResponseDTO.PostRegisterResultDTO toRegisterResultDTO(Post post){
         return PostResponseDTO.PostRegisterResultDTO.builder()
                 .title(post.getTitle())
                 .id(post.getId())
-                .chat_room_id(chatRoom.getId())
+                .chat_room_id(post.getChatRoom().getId())
                 .member_id(post.getWriter().getId())
                 .build();
     }
@@ -21,6 +21,8 @@ public class PostConverter {
     public static Page<PostResponseDTO.PostDTO> toPostPageDTO(Page<Post> postPage) {
         return postPage.map(p -> new PostResponseDTO.PostDTO(
                 p.getId(),
+                p.getWriter().getId(),
+                p.getChatRoom().getId(),
                 p.getTitle(),
                 p.getPostStartStation().getStation().getName(),
                 p.getPostStartStation().getStation().getLine(),

--- a/src/main/java/submeet/backend/converter/PostConverter.java
+++ b/src/main/java/submeet/backend/converter/PostConverter.java
@@ -1,6 +1,7 @@
 package submeet.backend.converter;
 
 import org.springframework.data.domain.Page;
+import submeet.backend.entity.ChatRoom;
 import submeet.backend.entity.Post;
 import submeet.backend.web.dto.post.PostResponseDTO;
 
@@ -8,10 +9,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class PostConverter {
-    public static PostResponseDTO.PostRegisterResultDTO toRegisterResultDTO(Post post){
+    public static PostResponseDTO.PostRegisterResultDTO toRegisterResultDTO(Post post, ChatRoom chatRoom){
         return PostResponseDTO.PostRegisterResultDTO.builder()
                 .title(post.getTitle())
                 .id(post.getId())
+                .chat_room_id(chatRoom.getId())
+                .member_id(post.getWriter().getId())
                 .build();
     }
 

--- a/src/main/java/submeet/backend/entity/Post.java
+++ b/src/main/java/submeet/backend/entity/Post.java
@@ -36,4 +36,8 @@ public class Post extends BaseEntity {
     private PostStartStation postStartStation;
     @OneToOne(mappedBy = "post")
     private PostEndStation postEndStation;
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    Member writer;
 }

--- a/src/main/java/submeet/backend/entity/Post.java
+++ b/src/main/java/submeet/backend/entity/Post.java
@@ -40,4 +40,11 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     Member writer;
+    @OneToOne(mappedBy = "post")
+    ChatRoom chatRoom;
+
+
+    public void setChatRoom(ChatRoom chatRoom) {
+        this.chatRoom = chatRoom;
+    }
 }

--- a/src/main/java/submeet/backend/handler/StompHandler.java
+++ b/src/main/java/submeet/backend/handler/StompHandler.java
@@ -1,0 +1,36 @@
+package submeet.backend.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import submeet.backend.apiPayLoad.code.status.ErrorStatus;
+import submeet.backend.apiPayLoad.exception.handler.ChatHandler;
+import submeet.backend.security.TokenService;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+public class StompHandler implements ChannelInterceptor {
+    private final TokenService tokenService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        // 웹소켓 연결시 헤더의 jwt token 유효성 검증
+        if(StompCommand.CONNECT == accessor.getCommand()){
+            String authorization = tokenService.extractJwt(accessor.getFirstNativeHeader("Authorization"));
+            if(tokenService.verifyToken(authorization)){
+                throw new ChatHandler(ErrorStatus.UNAUTHORIZED);
+            }
+        }
+        return message;
+    }
+}

--- a/src/main/java/submeet/backend/repository/ChatRepository.java
+++ b/src/main/java/submeet/backend/repository/ChatRepository.java
@@ -2,6 +2,10 @@ package submeet.backend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import submeet.backend.entity.ChatRoom;
+import submeet.backend.entity.Post;
+
+import java.util.Optional;
 
 public interface ChatRepository extends JpaRepository<ChatRoom, Long> {
+    public Optional<ChatRoom> findByPost(Post post);
 }

--- a/src/main/java/submeet/backend/security/SecurityConfig.java
+++ b/src/main/java/submeet/backend/security/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                         .requestMatchers("/api/member/join","/token/**","/health/**").permitAll()
+                        .requestMatchers("/stomp/**").permitAll()
                         .anyRequest().authenticated())
 
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/src/main/java/submeet/backend/security/TokenService.java
+++ b/src/main/java/submeet/backend/security/TokenService.java
@@ -68,6 +68,13 @@ public class TokenService {
         return null;
     }
 
+    public String extractJwt(String bearerToken){
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
     public String getUid(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }

--- a/src/main/java/submeet/backend/service/Chatting/ChatCommandService.java
+++ b/src/main/java/submeet/backend/service/Chatting/ChatCommandService.java
@@ -5,7 +5,7 @@ import submeet.backend.entity.Member;
 import submeet.backend.web.dto.chat.ChatRequestDTO;
 
 public interface ChatCommandService {
-    public ChatRoom createChatRoom(ChatRequestDTO.ChatCreateResponseDTO chatCreateResponseDTO);
+    public ChatRoom createChatRoom(ChatRequestDTO.ChatCreateRequestDTO chatCreateRequestDTO);
     public void plusUserCnt(Long roomId);
     public void minusUserCnt(Long roomId);
     public Member addMember(Long roomId, Long memberId);

--- a/src/main/java/submeet/backend/service/Chatting/ChatCommandServiceImpl.java
+++ b/src/main/java/submeet/backend/service/Chatting/ChatCommandServiceImpl.java
@@ -29,12 +29,12 @@ public class ChatCommandServiceImpl implements ChatCommandService {
 
     @Override
     @Transactional
-    public ChatRoom createChatRoom(ChatRequestDTO.ChatCreateResponseDTO chatCreateResponseDTO) {
-        Post post = postRepository.findById(chatCreateResponseDTO.getPost_id()).orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
+    public ChatRoom createChatRoom(ChatRequestDTO.ChatCreateRequestDTO chatCreateRequestDTO) {
+        Post post = postRepository.findById(chatCreateRequestDTO.getPost_id()).orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .post(post)
-                .appointmentTime(chatCreateResponseDTO.getAppointment_time())
+                .appointmentTime(chatCreateRequestDTO.getAppointment_time())
                 .userCount(0L)
                 .build();
        return chatRepository.save(chatRoom);

--- a/src/main/java/submeet/backend/service/Chatting/ChatCommandServiceImpl.java
+++ b/src/main/java/submeet/backend/service/Chatting/ChatCommandServiceImpl.java
@@ -37,6 +37,7 @@ public class ChatCommandServiceImpl implements ChatCommandService {
                 .appointmentTime(chatCreateRequestDTO.getAppointment_time())
                 .userCount(0L)
                 .build();
+        post.setChatRoom(chatRoom);
        return chatRepository.save(chatRoom);
     }
 

--- a/src/main/java/submeet/backend/service/Chatting/ChatQueryService.java
+++ b/src/main/java/submeet/backend/service/Chatting/ChatQueryService.java
@@ -4,4 +4,5 @@ import submeet.backend.entity.ChatRoom;
 
 public interface ChatQueryService {
     public ChatRoom findById(Long roomId);
+    public ChatRoom findByPostId(Long postId);
 }

--- a/src/main/java/submeet/backend/service/Chatting/ChatQueryServiceImpl.java
+++ b/src/main/java/submeet/backend/service/Chatting/ChatQueryServiceImpl.java
@@ -5,17 +5,29 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import submeet.backend.apiPayLoad.code.status.ErrorStatus;
 import submeet.backend.apiPayLoad.exception.handler.ChatHandler;
+import submeet.backend.apiPayLoad.exception.handler.PostHandler;
 import submeet.backend.entity.ChatRoom;
+import submeet.backend.entity.Post;
 import submeet.backend.repository.ChatRepository;
+import submeet.backend.repository.PostRepository;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatQueryServiceImpl implements ChatQueryService{
     private final ChatRepository chatRepository;
+    private final PostRepository postRepository;
 
     @Override
     public ChatRoom findById(Long roomId) {
         return chatRepository.findById(roomId).orElseThrow(()->new ChatHandler(ErrorStatus.CHAT_ROOM_NOT_FOUND));
     }
+
+    @Override
+    public ChatRoom findByPostId(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostHandler(ErrorStatus.POST_NOT_FOUND));
+        return chatRepository.findByPost(post).orElseThrow(()->new ChatHandler(ErrorStatus.CHAT_ROOM_NOT_FOUND));
+    }
+
+
 }

--- a/src/main/java/submeet/backend/service/post/PostCommandService.java
+++ b/src/main/java/submeet/backend/service/post/PostCommandService.java
@@ -1,8 +1,9 @@
 package submeet.backend.service.post;
 
+import jakarta.servlet.http.HttpServletRequest;
 import submeet.backend.entity.Post;
 import submeet.backend.web.dto.post.PostRequestDTO;
 
 public interface PostCommandService {
-    public Post register(PostRequestDTO.PostRegisterDTO postRegisterDTO);
+    public Post register(PostRequestDTO.PostRegisterDTO postRegisterDTO, HttpServletRequest httpServletRequest);
 }

--- a/src/main/java/submeet/backend/web/controller/ChatRoomController.java
+++ b/src/main/java/submeet/backend/web/controller/ChatRoomController.java
@@ -17,8 +17,8 @@ public class ChatRoomController {
      * 채팅방 생성
      */
     @PostMapping("/room")
-    public ChatResponseDTO.ChatCreateResultDTO createRoom(@RequestBody ChatRequestDTO.ChatCreateResponseDTO chatCreateResponseDTO){
-        ChatRoom chatRoom = chatCommandService.createChatRoom(chatCreateResponseDTO);
+    public ChatResponseDTO.ChatCreateResultDTO createRoom(@RequestBody ChatRequestDTO.ChatCreateRequestDTO chatCreateRequestDTO){
+        ChatRoom chatRoom = chatCommandService.createChatRoom(chatCreateRequestDTO);
         return ChatConverter.toChatCreateResultDTO(chatRoom);
     }
 

--- a/src/main/java/submeet/backend/web/controller/PostController.java
+++ b/src/main/java/submeet/backend/web/controller/PostController.java
@@ -1,5 +1,6 @@
 package submeet.backend.web.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
@@ -7,11 +8,15 @@ import submeet.backend.apiPayLoad.ApiResponse;
 import submeet.backend.apiPayLoad.code.status.SuccessStatus;
 import submeet.backend.converter.PostConverter;
 import submeet.backend.converter.StationConverter;
+import submeet.backend.entity.ChatRoom;
 import submeet.backend.entity.Post;
 import submeet.backend.entity.Station;
+import submeet.backend.security.TokenService;
+import submeet.backend.service.Chatting.ChatCommandService;
 import submeet.backend.service.post.PostCommandService;
 import submeet.backend.service.post.PostQueryService;
 import submeet.backend.validation.annotation.CheckPage;
+import submeet.backend.web.dto.chat.ChatRequestDTO;
 import submeet.backend.web.dto.post.PostRequestDTO;
 import submeet.backend.web.dto.post.PostResponseDTO;
 import submeet.backend.web.dto.station.StationRequestDTO;
@@ -25,6 +30,7 @@ import java.util.List;
 public class PostController {
     private final PostCommandService postCommandService;
     private final PostQueryService postQueryService;
+    private final ChatCommandService chatCommandService;
 
     /**
      * 게시물 등록
@@ -32,9 +38,16 @@ public class PostController {
      * @return
      */
     @PostMapping
-    public ApiResponse<PostResponseDTO.PostRegisterResultDTO> register(@RequestBody PostRequestDTO.PostRegisterDTO postRegisterDTO){
-        Post post = postCommandService.register(postRegisterDTO);
-        PostResponseDTO.PostRegisterResultDTO registerResultDTO = PostConverter.toRegisterResultDTO(post);
+    public ApiResponse<PostResponseDTO.PostRegisterResultDTO> register(@RequestBody PostRequestDTO.PostRegisterDTO postRegisterDTO, HttpServletRequest httpServletRequest){
+        Post post = postCommandService.register(postRegisterDTO,httpServletRequest);
+
+        ChatRequestDTO.ChatCreateRequestDTO chatCreatRequestDTO = ChatRequestDTO.ChatCreateRequestDTO.builder()
+                .post_id(post.getId())
+                .appointment_time(post.getStart_time())
+                .build();
+        ChatRoom chatRoom = chatCommandService.createChatRoom(chatCreatRequestDTO);
+
+        PostResponseDTO.PostRegisterResultDTO registerResultDTO = PostConverter.toRegisterResultDTO(post, chatRoom);
         return ApiResponse.of(SuccessStatus.POST_REGISTER,registerResultDTO);
     }
 

--- a/src/main/java/submeet/backend/web/controller/PostController.java
+++ b/src/main/java/submeet/backend/web/controller/PostController.java
@@ -45,9 +45,9 @@ public class PostController {
                 .post_id(post.getId())
                 .appointment_time(post.getStart_time())
                 .build();
-        ChatRoom chatRoom = chatCommandService.createChatRoom(chatCreatRequestDTO);
+        chatCommandService.createChatRoom(chatCreatRequestDTO);
 
-        PostResponseDTO.PostRegisterResultDTO registerResultDTO = PostConverter.toRegisterResultDTO(post, chatRoom);
+        PostResponseDTO.PostRegisterResultDTO registerResultDTO = PostConverter.toRegisterResultDTO(post);
         return ApiResponse.of(SuccessStatus.POST_REGISTER,registerResultDTO);
     }
 

--- a/src/main/java/submeet/backend/web/dto/chat/ChatRequestDTO.java
+++ b/src/main/java/submeet/backend/web/dto/chat/ChatRequestDTO.java
@@ -1,12 +1,18 @@
 package submeet.backend.web.dto.chat;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 public class ChatRequestDTO {
     @Getter
-    public static class ChatCreateResponseDTO{
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChatCreateRequestDTO {
         Long post_id;
         LocalDateTime appointment_time;
     }

--- a/src/main/java/submeet/backend/web/dto/post/PostResponseDTO.java
+++ b/src/main/java/submeet/backend/web/dto/post/PostResponseDTO.java
@@ -26,6 +26,8 @@ public class PostResponseDTO {
     @Getter
     public static class PostDTO{
         private Long post_id;
+        private Long member_id;
+        private Long chat_room_id;
         private String post_title;
         private String departure_station;
         private String departure_station_line;

--- a/src/main/java/submeet/backend/web/dto/post/PostResponseDTO.java
+++ b/src/main/java/submeet/backend/web/dto/post/PostResponseDTO.java
@@ -15,6 +15,8 @@ public class PostResponseDTO {
     @Getter
     public static class PostRegisterResultDTO{
         private Long id;
+        private Long chat_room_id;
+        private Long member_id;
         private String title;
     }
 


### PR DESCRIPTION
- 웹소켓 인증절차를 구현
  - 그러나 오류가 발생해 이 구현 적용은 나중으로 미루고 일단 security에서 filter 거치지 않게 함

- 밋 만들 때 작성자를 추가하고 채팅방을 개설
  - 채팅방 id, member id 를 밋 검색시에 return

```json
{
        "post_id": 0,
        "member_id": 0,
        "chat_room_id": 0,
        "post_title": "string",
        "departure_station": "string",
        "departure_station_line": "string",
        "destination_station": "string",
        "destination_station_line": "string",
        "category": "string",
        "age_range": 0,
        "created_at": "2024-05-28T08:49:20.815Z",
        "start_time": "2024-05-28T08:49:20.815Z",
        "end_time": "2024-05-28T08:49:20.815Z",
        "participants": 0,
        "current_participants": 0,
        "description": "string",
        "gender": 0,
        "status": 0
      }
```