### PR TITLE
Setting : STOMP NGINX 세팅

### DIFF
--- a/.platform/nginx.conf
+++ b/.platform/nginx.conf
@@ -49,6 +49,13 @@ http {
           proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       }
 
+      location ~ /stomp/chat/ {
+        proxy_pass http://springboot;
+        proxy_http_version 1.1;
+        proxy_set_header upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+      }
+
       access_log    /var/log/nginx/access.log main;
 
       client_header_timeout 60;


### PR DESCRIPTION
이슈번호 : #47 

 로컬환경에서 잘 되던 STOMP 연결이 AWS 서버에 올라가면서 연결이 안됨
 NGINX 세팅에 웹소켓 세팅을 추가로 해줬음
```

      location ~ /stomp/chat/ {
        proxy_pass http://springboot;
        proxy_http_version 1.1;
        proxy_set_header upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
      }


```