### PR TITLE
Fix : 채팅방 나가기 버그 fix

### DIFF
--- a/src/main/java/submeet/backend/web/controller/MessageController.java
+++ b/src/main/java/submeet/backend/web/controller/MessageController.java
@@ -64,9 +64,9 @@ public class MessageController {
     public void leave(ChatMessageDTO message){
         message.setMessageType(MessageType.LEAVE.toString());
         message.setMessage(memberQueryService.findMember(message.getMemberId()).getNickName() + "님이 채팅방에서 나갔습니다.");
+        messageCommandService.save(message);
         chatCommandService.delMember(message.getChatRoomId(), message.getMemberId());
         chatCommandService.minusUserCnt(message.getChatRoomId());
-        messageCommandService.save(message);
         template.convertAndSend("/sub/chat/room/" + message.getChatRoomId(), message);
     }
 


### PR DESCRIPTION
fix 완료

```java
    @MessageMapping(value = "/chat/leave")
    public void leave(ChatMessageDTO message){
        message.setMessageType(MessageType.LEAVE.toString());
        message.setMessage(memberQueryService.findMember(message.getMemberId()).getNickName() + "님이 채팅방에서 나갔습니다.");
        messageCommandService.save(message);
        chatCommandService.delMember(message.getChatRoomId(), message.getMemberId());
        chatCommandService.minusUserCnt(message.getChatRoomId());
        template.convertAndSend("/sub/chat/room/" + message.getChatRoomId(), message);
    }
```
순서를 바꾸는 것으로 문제 해결