### PR TITLE
Feat/52 : 채팅 관련 API 구현

### DIFF
--- a/src/main/java/submeet/backend/apiPayLoad/code/status/SuccessStatus.java
+++ b/src/main/java/submeet/backend/apiPayLoad/code/status/SuccessStatus.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import submeet.backend.apiPayLoad.code.BaseCode;
-import submeet.backend.apiPayLoad.code.BaseErrorCode;
 import submeet.backend.apiPayLoad.code.ReasonDTO;
 
 @Getter
@@ -16,6 +15,7 @@ public enum SuccessStatus implements BaseCode {
     //멤버 관련 응답
     MEMBER_JOIN(HttpStatus.OK, "MEMBER2001", "member joined"),
     MEMBER_LOGIN(HttpStatus.OK, "MEMBER2002" , "login success!" ),
+    MEMBER_FOUND(HttpStatus.OK,"MEMBER2003", "member found!"),
     //게시글 관련 응답
     POST_REGISTER(HttpStatus.OK, "POST2001", "post registered"),
     POST_SPATIAL_SEARCH(HttpStatus.OK, "POST2002", "post spatial search success"),
@@ -26,7 +26,11 @@ public enum SuccessStatus implements BaseCode {
     STATION_SPATIAL_SEARCH(HttpStatus.OK,"STATION2003","station spatial search success"),
     STATION_LOCATION_SEARCH(HttpStatus.OK, "STATION2004", "station location search success"),
     //토큰 관련 응답
-    TOKEN_REFRESHED(HttpStatus.UNAUTHORIZED,"TOKEN2001", "Token Refreshed");
+    TOKEN_REFRESHED(HttpStatus.UNAUTHORIZED,"TOKEN2001", "Token Refreshed"),
+    //채팅 관련 응답
+    CHAT_MEMBERS(HttpStatus.OK,"CHAT2001","find member List success"),
+    CHATS_FOUND(HttpStatus.OK,"CHAT2002","find member List success"),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/submeet/backend/converter/ChatConverter.java
+++ b/src/main/java/submeet/backend/converter/ChatConverter.java
@@ -1,12 +1,28 @@
 package submeet.backend.converter;
 
 import submeet.backend.entity.ChatRoom;
+import submeet.backend.entity.MemberChat;
 import submeet.backend.web.dto.chat.ChatResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ChatConverter {
     public static ChatResponseDTO.ChatCreateResultDTO toChatCreateResultDTO(ChatRoom chatRoom){
         return ChatResponseDTO.ChatCreateResultDTO.builder()
                 .chat_room_id(chatRoom.getId())
                 .build();
+    }
+
+    public static List<ChatResponseDTO.ChatRoomDTO> toChatDTOList(List<ChatRoom> chatList) {
+        return chatList.stream()
+                .map(c -> {return ChatResponseDTO.ChatRoomDTO.builder()
+                        .chat_room_id(c.getId())
+                        .appointment_time(c.getAppointmentTime())
+                        .post_id(c.getPost().getId())
+                        .user_count(c.getUserCount())
+                        .build();}
+                )
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/submeet/backend/converter/MemberChatConverter.java
+++ b/src/main/java/submeet/backend/converter/MemberChatConverter.java
@@ -1,0 +1,24 @@
+package submeet.backend.converter;
+
+import submeet.backend.entity.ChatRoom;
+import submeet.backend.entity.Member;
+import submeet.backend.entity.MemberChat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MemberChatConverter {
+    public static List<Member> toMemberList(List<MemberChat> memberChatList){
+        return memberChatList.stream()
+                .filter(MemberChat::getStatus)
+                .map(MemberChat::getMember)
+                .toList();
+    }
+
+    public static List<ChatRoom> toChatList(List<MemberChat> memberChatList) {
+        return memberChatList.stream()
+                .filter(MemberChat::getStatus)
+                .map(MemberChat::getChatRoom)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/submeet/backend/converter/MemberConverter.java
+++ b/src/main/java/submeet/backend/converter/MemberConverter.java
@@ -6,6 +6,8 @@ import submeet.backend.web.dto.member.MemberRequestDTO;
 import submeet.backend.web.dto.member.MemberResponseDTO;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemberConverter {
 
@@ -21,6 +23,18 @@ public class MemberConverter {
     public static MemberRequestDTO.MemberDTO toMemberDTO(Member member){
         return MemberRequestDTO.MemberDTO.builder()
                 .id(member.getId())
+                .nick_name(member.getNickName())
+                .email(member.getEmail())
+                .profile_image(member.getProfile_image())
+                .gender(member.getGender())
+                .age(member.getAge())
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberDTO toMemberResponseDTO(Member member){
+        return MemberResponseDTO.MemberDTO.builder()
+                .member_id(member.getId())
+                .nick_name(member.getNickName())
                 .email(member.getEmail())
                 .profile_image(member.getProfile_image())
                 .gender(member.getGender())
@@ -35,5 +49,22 @@ public class MemberConverter {
                 .refreshToken(token.getRefreshToken())
                 .expiration(localDateTime)
                 .build();
+    }
+
+    public static List<MemberResponseDTO.MemberDTO> toMemberDTOList(List<Member> memberList) {
+        return memberList.stream()
+                .map(
+                        m -> {
+                            return MemberResponseDTO.MemberDTO.builder()
+                                    .member_id(m.getId())
+                                    .age(m.getAge())
+                                    .nick_name(m.getNickName())
+                                    .email(m.getEmail())
+                                    .profile_image(m.getProfile_image())
+                                    .gender(m.getGender())
+                                    .build();
+                        }
+                )
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/submeet/backend/repository/MemberChatRepository.java
+++ b/src/main/java/submeet/backend/repository/MemberChatRepository.java
@@ -5,9 +5,12 @@ import submeet.backend.entity.ChatRoom;
 import submeet.backend.entity.Member;
 import submeet.backend.entity.MemberChat;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberChatRepository extends JpaRepository<MemberChat, Long> {
     public Optional<MemberChat> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
     public boolean existsByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+    public List<MemberChat> findByChatRoom(ChatRoom chatRoom);
+    public List<MemberChat> findByMember(Member member);
 }

--- a/src/main/java/submeet/backend/service/member/MemberQueryService.java
+++ b/src/main/java/submeet/backend/service/member/MemberQueryService.java
@@ -7,4 +7,6 @@ public interface MemberQueryService {
     public Member findMember(Long memberId);
 
     public Member login(HttpServletRequest httpServletRequest);
+
+    public Member findMemberByEmail(String email);
 }

--- a/src/main/java/submeet/backend/service/member/MemberQueryServiceImpl.java
+++ b/src/main/java/submeet/backend/service/member/MemberQueryServiceImpl.java
@@ -27,4 +27,9 @@ public class MemberQueryServiceImpl implements MemberQueryService{
         String email = tokenService.getUid(givenToken);
         return memberRepository.findByEmail(email).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
+
+    @Override
+    public Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(()->new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/submeet/backend/web/controller/ChatRoomController.java
+++ b/src/main/java/submeet/backend/web/controller/ChatRoomController.java
@@ -2,17 +2,32 @@ package submeet.backend.web.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import submeet.backend.apiPayLoad.ApiResponse;
+import submeet.backend.apiPayLoad.code.status.SuccessStatus;
 import submeet.backend.converter.ChatConverter;
+import submeet.backend.converter.MemberChatConverter;
+import submeet.backend.converter.MemberConverter;
 import submeet.backend.entity.ChatRoom;
+import submeet.backend.entity.Member;
+import submeet.backend.entity.MemberChat;
+import submeet.backend.repository.MemberChatRepository;
 import submeet.backend.service.Chatting.ChatCommandService;
+import submeet.backend.service.Chatting.ChatQueryService;
+import submeet.backend.service.member.MemberQueryService;
 import submeet.backend.web.dto.chat.ChatRequestDTO;
 import submeet.backend.web.dto.chat.ChatResponseDTO;
+import submeet.backend.web.dto.member.MemberResponseDTO;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chat")
 public class ChatRoomController {
     private final ChatCommandService chatCommandService;
+    private final ChatQueryService chatQueryService;
+    private final MemberChatRepository memberChatRepository;
+    private final MemberQueryService memberQueryService;
     /**
      * 채팅방 생성
      */
@@ -22,4 +37,37 @@ public class ChatRoomController {
         return ChatConverter.toChatCreateResultDTO(chatRoom);
     }
 
+    /**
+     * chatRoomId인 채팅방에 참여중인 member 반환
+     * @param chatRoomId
+     * @return
+     */
+    @GetMapping("/room/members/{chatRoomId}")
+    public ApiResponse<ChatResponseDTO.MemberListDTO> findMemberList(@PathVariable Long chatRoomId){
+        ChatRoom chatRoom = chatQueryService.findById(chatRoomId);
+        List<MemberChat> memberChatList = memberChatRepository.findByChatRoom(chatRoom);
+        List<Member> memberList = MemberChatConverter.toMemberList(memberChatList);
+        List<MemberResponseDTO.MemberDTO> memberDTOList = MemberConverter.toMemberDTOList(memberList);
+        ChatResponseDTO.MemberListDTO result = ChatResponseDTO.MemberListDTO.builder()
+                .member_list(memberDTOList)
+                .build();
+        return ApiResponse.of(SuccessStatus.CHAT_MEMBERS,result);
+    }
+
+    /**
+     * member가 참여중인 채팅방 목록 반환
+     * @param memberId
+     * @return
+     */
+    @GetMapping("/rooms/{memberId}")
+    public ApiResponse<ChatResponseDTO.ChatListDTO> findChatList(@PathVariable Long memberId){
+        Member member = memberQueryService.findMember(memberId);
+        List<MemberChat> memberChatList = memberChatRepository.findByMember(member);
+        List<ChatRoom> chatList = MemberChatConverter.toChatList(memberChatList);
+        List<ChatResponseDTO.ChatRoomDTO> chatRoomDTOList = ChatConverter.toChatDTOList(chatList);
+        ChatResponseDTO.ChatListDTO result = ChatResponseDTO.ChatListDTO.builder()
+                .chat_list(chatRoomDTOList)
+                .build();
+        return ApiResponse.of(SuccessStatus.CHATS_FOUND,result);
+    }
 }

--- a/src/main/java/submeet/backend/web/controller/MemberController.java
+++ b/src/main/java/submeet/backend/web/controller/MemberController.java
@@ -44,5 +44,12 @@ public class MemberController {
         return ApiResponse.of(SuccessStatus.MEMBER_LOGIN, MemberConverter.toLoginResultDTO(member, newToken, expiration) );
     }
 
+    @GetMapping
+    public ApiResponse<MemberResponseDTO.MemberDTO> getMember(HttpServletRequest httpServletRequest){
+        String token = tokenService.getJwtFromHeader(httpServletRequest);
+        String email = tokenService.getUid(token);
+        Member member = memberQueryService.findMemberByEmail(email);
+        return ApiResponse.of(SuccessStatus.MEMBER_FOUND, MemberConverter.toMemberResponseDTO(member));
+    }
 
 }

--- a/src/main/java/submeet/backend/web/dto/chat/ChatResponseDTO.java
+++ b/src/main/java/submeet/backend/web/dto/chat/ChatResponseDTO.java
@@ -4,6 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import submeet.backend.web.dto.member.MemberResponseDTO;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ChatResponseDTO {
     @Getter
@@ -12,5 +17,30 @@ public class ChatResponseDTO {
     @NoArgsConstructor
     public static class ChatCreateResultDTO{
         private Long chat_room_id;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MemberListDTO {
+        private List<MemberResponseDTO.MemberDTO> member_list;
+    }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChatListDTO{
+        private List<ChatResponseDTO.ChatRoomDTO> chat_list;
+    }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChatRoomDTO {
+        private Long chat_room_id;
+        private LocalDateTime appointment_time;
+        private Long post_id;
+        private Long user_count;
     }
 }

--- a/src/main/java/submeet/backend/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/submeet/backend/web/dto/member/MemberResponseDTO.java
@@ -29,4 +29,17 @@ public class MemberResponseDTO {
         private String refreshToken;
         private LocalDateTime expiration;
     }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MemberDTO{
+        private Long member_id;
+        private Integer age;
+        private String nick_name;
+        private String profile_image;
+        private String email;
+        private Boolean gender;
+    }
 }


### PR DESCRIPTION
- 채팅 관련 API 구현

1. 
![image](https://github.com/SUB-Meet/submeet-backend/assets/86874804/26390cc4-aed0-4e66-91e1-eef0c4cd38de)

Get 요청 : /chat/rooms/{memberId}

Response : 
```json
{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "chat_list": [
      {
        "chat_room_id": 0,
        "appointment_time": "2024-05-29T12:51:04.616Z",
        "post_id": 0,
        "user_count": 0
      }
    ]
  }
}
```

==> member 가 참여하고 있는 모든 채팅 반환


2. 
![image](https://github.com/SUB-Meet/submeet-backend/assets/86874804/e2a2ebf1-6f83-40cc-89ca-c40823bbb06d)

Get 요청 : /chat/room/members/{chatRoomId}

Response : 
```json
{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "member_list": [
      {
        "member_id": 0,
        "age": 0,
        "nick_name": "string",
        "profile_image": "string",
        "email": "string",
        "gender": true
      }
    ]
  }
}
```

==> 이 채팅에 참여하고 있는 모든 Member 반환